### PR TITLE
Catch requests execeptions and reraise as PyeEmbedError

### DIFF
--- a/pyembed/core/__init__.py
+++ b/pyembed/core/__init__.py
@@ -20,8 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import requests
 from pyembed.core import consumer
 from pyembed.core.discovery import DefaultDiscoverer
+from pyembed.core.error import PyEmbedError
 from pyembed.core.render import DefaultRenderer
 
 
@@ -47,7 +49,10 @@ class PyEmbed(object):
         :returns: an HTML representation of the resource.
         :raises PyEmbedError: if there is an error fetching the response.
         """
-        oembed_urls = self.discoverer.get_oembed_urls(url)
+        try:
+            oembed_urls = self.discoverer.get_oembed_urls(url)
+        except requests.exceptions.RequestException as e:
+            raise PyEmbedError(e)
         response = consumer.get_first_oembed_response(
             oembed_urls, max_width=max_width, max_height=max_height)
         return self.renderer.render(url, response)


### PR DESCRIPTION
requests would raise subclasses of requests.exeptions.RequestException, for example when you leave the scheme off.

This matches the documentation.