### PR TITLE
Set default discoverer and renderer to None

### DIFF
--- a/pyembed/core/__init__.py
+++ b/pyembed/core/__init__.py
@@ -29,11 +29,16 @@ from pyembed.core.render import DefaultRenderer
 
 
 class PyEmbed(object):
-    def __init__(self, discoverer=DefaultDiscoverer(), renderer=DefaultRenderer()):
+    def __init__(self, discoverer=None, renderer=None):
         """OEmbed consumer with automatic discovery.
 
         :param renderer: (optional) renderer to render the response.
         """
+        if not discoverer:
+            discoverer = DefaultDiscoverer()
+        if not renderer:
+            renderer = DefaultRenderer()
+
         self.discoverer = discoverer
         self.renderer = renderer
 


### PR DESCRIPTION
This prevents the library from querying the oembed site when first
imported