### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,15 +5,15 @@ PyEmbed
   :target: http://travis-ci.org/pyembed/pyembed
 .. image:: https://coveralls.io/repos/pyembed/pyembed/badge.png
   :target: https://coveralls.io/r/pyembed/pyembed
-.. image:: https://pypip.in/d/pyembed/badge.png
+.. image:: https://img.shields.io/pypi/dm/pyembed.svg
   :target: https://pypi.python.org/pypi/pyembed/
-.. image:: https://pypip.in/v/pyembed/badge.png
+.. image:: https://img.shields.io/pypi/v/pyembed.svg
   :target: https://pypi.python.org/pypi/pyembed/
-.. image:: https://pypip.in/wheel/pyembed/badge.png
+.. image:: https://img.shields.io/pypi/wheel/pyembed.svg
   :target: https://pypi.python.org/pypi/pyembed/
 .. image:: https://pypip.in/egg/pyembed/badge.png
   :target: https://pypi.python.org/pypi/pyembed/
-.. image:: https://pypip.in/license/pyembed/badge.png
+.. image:: https://img.shields.io/pypi/l/pyembed.svg
   :target: https://pypi.python.org/pypi/pyembed/
 
 `OEmbed`_ consumer library for Python with automatic discovery of


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyembed-rst))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyembed-rst`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.